### PR TITLE
bump: Bump to v0.2.12

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -18,7 +18,7 @@ Subtitle := "A library of antiassociative magmas of small order",
 ##  See '?Extending: Version Numbers' in GAP help for an explanation
 ##  of valid version numbers. For an automatic package distribution update
 ##  you must provide a new version number even after small changes.
-Version := "0.2.11",
+Version := "0.2.12",
 
 ##  Release date of the current version in dd/mm/yyyy format.
 Date := "28/08/2024",

--- a/tst/test_0_metadata.tst
+++ b/tst/test_0_metadata.tst
@@ -1,6 +1,6 @@
 gap> START_TEST( "test_0_metadata.tst" );
 
-gap> ValidatePackageInfo("PackageInfo.g");
+gap> ValidatePackageInfo(Filename(DirectoriesPackageLibrary("smallantimagmas", ""), "PackageInfo.g"));
 true
 
 gap> STOP_TEST( "test_0_metadata.tst" );


### PR DESCRIPTION
This fixes https://github.com/gap-system/PackageDistro/pull/1007 build to fail.